### PR TITLE
Pagination and Sorting

### DIFF
--- a/cashcard/src/main/java/com/springacademy/cashcard/CashCardController.java
+++ b/cashcard/src/main/java/com/springacademy/cashcard/CashCardController.java
@@ -1,10 +1,15 @@
 package com.springacademy.cashcard;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -36,9 +41,14 @@ public class CashCardController {
         return ResponseEntity.created(locationOfNewCashCard).build();
     }
 
-    @GetMapping()
-    private ResponseEntity<Iterable<CashCard>> findAll() {
-        return ResponseEntity.ok(cashCardRepository.findAll());
+    @GetMapping
+    private ResponseEntity<List<CashCard>> findAll(Pageable pageable) {
+        Page<CashCard> page = cashCardRepository.findAll(
+                PageRequest.of(
+                        pageable.getPageNumber(),
+                        pageable.getPageSize(),
+                        pageable.getSortOr(Sort.by(Sort.Direction.ASC, "amount"))
+                ));
+        return ResponseEntity.ok(page.getContent());
     }
-
 }

--- a/cashcard/src/main/java/com/springacademy/cashcard/CashCardRepository.java
+++ b/cashcard/src/main/java/com/springacademy/cashcard/CashCardRepository.java
@@ -1,9 +1,12 @@
 package com.springacademy.cashcard;
 
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
 /**
  * @author Fellipe Toledo
  */
-public interface CashCardRepository extends CrudRepository<CashCard, Long> {
+public interface CashCardRepository extends
+        CrudRepository<CashCard, Long>,
+        PagingAndSortingRepository<CashCard, Long> {
 }

--- a/cashcard/src/test/java/com/springacademy/cashcard/CashcardApplicationTests.java
+++ b/cashcard/src/test/java/com/springacademy/cashcard/CashcardApplicationTests.java
@@ -43,6 +43,7 @@ class CashcardApplicationTests {
 		assertThat(response.getBody()).isBlank();
 	}
 
+	//POST
 	@Test
 	@DirtiesContext
 	void shouldCreateANewCashCard() {
@@ -62,6 +63,7 @@ class CashcardApplicationTests {
 		assertThat(amount).isEqualTo(250.00);
 	}
 
+	//LIST
 	@Test
 	void shouldReturnAllCashCardsWhenListIsRequested() {
 		ResponseEntity<String> response = restTemplate.getForEntity("/cashcards", String.class);
@@ -76,6 +78,44 @@ class CashcardApplicationTests {
 
 		JSONArray amounts = documentContext.read("$..amount");
 		assertThat(amounts).containsExactlyInAnyOrder(123.45, 1.00, 150.00);
+	}
+
+	//PAGINATION
+	@Test
+	void shouldReturnAPageOfCashCards() {
+		ResponseEntity<String> response = restTemplate.getForEntity("/cashcards?page=0&size=1", String.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+		DocumentContext documentContext = JsonPath.parse(response.getBody());
+		JSONArray page = documentContext.read("$[*]");
+		assertThat(page.size()).isEqualTo(1);
+	}
+
+	//SORTING
+	@Test
+	void shouldReturnASortedPageOfCashCards() {
+		ResponseEntity<String> response = restTemplate.getForEntity("/cashcards?page=0&size=1&sort=amount,desc", String.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+		DocumentContext documentContext = JsonPath.parse(response.getBody());
+		JSONArray read = documentContext.read("$[*]");
+		assertThat(read.size()).isEqualTo(1);
+
+		double amount = documentContext.read("$[0].amount");
+		assertThat(amount).isEqualTo(150.00);
+	}
+
+	@Test
+	void shouldReturnASortedPageOfCashCardsWithNoParametersAndUseDefaultValues() {
+		ResponseEntity<String> response = restTemplate.getForEntity("/cashcards", String.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+		DocumentContext documentContext = JsonPath.parse(response.getBody());
+		JSONArray page = documentContext.read("$[*]");
+		assertThat(page.size()).isEqualTo(3);
+
+		JSONArray amounts = documentContext.read("$..amount");
+		assertThat(amounts).containsExactly(1.00, 123.45, 150.00);
 	}
 }
 


### PR DESCRIPTION
Implemented a “GET many” endpoint and added sorting and pagination. This enabled two things:

Ensure that the data received from the server is in a predictable and understandable order.
Protect the client and server from being overwhelmed by a large amount of data (the size of the page places a limit on the amount of data that can be returned in a single response).

## Features
- Add the shouldReturnASortedPageOfCashCards test.
- Implement pagination and sorting in the CashCardController.
- Extend PagingAndSortingRepository
- Paging and Sorting defaults
